### PR TITLE
swapped p-tags for spans and added parent-child styling

### DIFF
--- a/src/components/CharacterSheet.js
+++ b/src/components/CharacterSheet.js
@@ -11,6 +11,9 @@ const StyledSheet = styled.div`
   padding: 2%;
   background-color: rgba(160, 82, 44, .7);
   box-shadow: 3px 3px 5px 8px rgba(160, 82, 44, .7);
+  & > span {
+    display: block;
+  }
 `
 
 class CharacterSheet extends Component {
@@ -64,10 +67,10 @@ class CharacterSheet extends Component {
     return(
       <>
         <StyledSheet>
-          <p>Race: {this.state.race}</p>
-          <p>Class: {this.state.class}</p>
-          <p>Background: {this.state.background}</p>
-          <p>Stats: {statList}</p>
+          <span>Race: {this.state.race}</span>
+          <span>Class: {this.state.class}</span>
+          <span>Background: {this.state.background}</span>
+          <span>Stats: {statList}</span>
         </StyledSheet>
         <Button onClick={this.rollCharacter} />
       </>


### PR DESCRIPTION
swapped p tags for spans to follow html standards. added parent-child styling to StyledSheet so that all spans would have display: block (this allows them to break vertically without <br> or <p> tags).